### PR TITLE
Feature/add tests interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Gemfile.lock
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+/reports/*
+!/reports/.keep

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'faker', '~> 1.9', '>= 1.9.3'
   gem 'colorize', '~> 0.8.1'
+  gem 'rspec-rails', '~> 3.8', '>= 3.8.2'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test do
   gem 'colorize', '~> 0.8.1'
   gem 'rspec-rails', '~> 3.8', '>= 3.8.2'
   gem 'factory_bot_rails', '~> 5.0', '>= 5.0.2'
+  gem 'database_cleaner', '~> 1.7'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :development, :test do
   gem 'faker', '~> 1.9', '>= 1.9.3'
   gem 'colorize', '~> 0.8.1'
   gem 'rspec-rails', '~> 3.8', '>= 3.8.2'
+  gem 'factory_bot_rails', '~> 5.0', '>= 5.0.2'
 end
 
 group :development do

--- a/lib/tasks/rspec_html.rake
+++ b/lib/tasks/rspec_html.rake
@@ -1,0 +1,10 @@
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.rspec_opts = '--format html --out ./reports/rspec_results.html'
+end
+
+namespace :rspec_report do
+  desc 'Run all specs and generate RSpec report in HTML'
+  task :html => :spec
+end

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :fake_students, class: Student do
+    name { Faker::Name.name }
+    cpf { Faker::Number.number(11) }
+    email { Faker::Internet.email }
+    phone { Faker::PhoneNumber.phone_number }
+    date_birth { Faker::Date.birthday(18, 65) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 
 # Add additional requires below this line. Rails is not loaded until this point!
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 begin
   ActiveRecord::Migration.maintain_test_schema!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,22 @@
+# This file is copied to spec/ when you run 'rails generate rspec:install'
+require 'spec_helper'
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path('../../config/environment', __FILE__)
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require 'rspec/rails'
+
+# Add additional requires below this line. Rails is not loaded until this point!
+
+begin
+  ActiveRecord::Migration.maintain_test_schema!
+rescue ActiveRecord::PendingMigrationError => e
+  puts e.to_s.strip
+  exit 1
+end
+
+RSpec.configure do |config|
+  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.use_transactional_fixtures = true
+  config.infer_spec_type_from_file_location!
+  config.filter_rails_from_backtrace!
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,7 +17,36 @@ end
 
 RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-  config.use_transactional_fixtures = true
+  
+  config.use_transactional_fixtures = false
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, :js => true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+
+  config.before(:all) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:all) do
+    DatabaseCleaner.clean
+  end
+
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 end

--- a/spec/requests/v1/students_spec.rb
+++ b/spec/requests/v1/students_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+describe "Get students", :type => :request do
+  let!(:students) {
+    FactoryBot.create_list(:fake_students, 20)
+  }
+
+  before {
+    get '/api/v1/students'
+  }
+
+  it 'returns all students' do
+    expect(JSON.parse(response.body).size).to eq(20)
+  end
+
+  it 'returns status code 200' do
+    expect(response).to have_http_status(:success)
+  end
+end
+
+describe "Create an student", :type => :request do
+  before do
+    post '/api/v1/students',
+    params: {
+      student: {
+        :name => 'Tony Stark',
+        :cpf => '19491363026', 
+        :email => 'tony.stark@avangers.marvel.hq', 
+        :phone => '27987819129', 
+        :date_birth => '1989-06-08' 
+      }
+    }
+  end
+  
+  it 'returns the student name' do
+    expect(JSON.parse(response.body)['name']).to eq(controller.params[:student][:name])
+  end
+  
+  it 'returns the cpf' do
+    expect(JSON.parse(response.body)['cpf']).to eq(controller.params[:student][:cpf])
+  end
+  
+  it 'returns the email' do
+    expect(JSON.parse(response.body)['email']).to eq(controller.params[:student][:email])
+  end
+  
+  it 'returns the phone' do
+    expect(JSON.parse(response.body)['phone']).to eq(controller.params[:student][:phone])
+  end
+  
+  it 'returns the date birth' do
+    expect(JSON.parse(response.body)['date_birth']).to eq(controller.params[:student][:date_birth])
+  end
+
+  it 'returns a created status' do
+    expect(response).to have_http_status(:created)
+  end
+end
+
+describe "Update an student" do
+  before(:each) do
+    @student = create(:fake_students)
+  end
+
+  it 'updates a student' do
+    @name = 'Steve Rogers'
+    
+    put "/api/v1/students/#{@student.id}", params: {
+      student: {
+        :name => @name,
+      }
+    }
+
+    expect(response).to have_http_status(:ok)
+    
+    expect(Student.find(@student.id).name).to eq(@name)
+  end
+end
+
+describe "Delete an student" do
+  before(:each) do
+    @student1 = create(:fake_students)
+    @student2 = create(:fake_students)
+  end
+
+  it 'should delete the student' do
+    get "/api/v1/students"
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)).to eq([
+      YAML.load(@student1.to_json),
+      YAML.load(@student2.to_json),
+    ])
+  
+    delete "/api/v1/students/#{@student1.id}"
+    expect(response).to have_http_status(:no_content)
+  
+    get "/api/v1/students"
+    expect(JSON.parse(response.body)).to eq([YAML.load(@student2.to_json)])
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,12 @@
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
Add RSpec test suit and an test sample for students resource.

Add another way to generate Rspec report via rake task and html output, only need run `docker-compose run --rm scms_web bin/rake rspec_report:html` and a file will be created on reports folder.

> obs: in test branch/merge it must be run a docker command build to install all RSpec bin in path.